### PR TITLE
Fix an issue of checking if it is a new doc.

### DIFF
--- a/lib/shortid.js
+++ b/lib/shortid.js
@@ -84,7 +84,7 @@ exports.plugin = function(schema, options) {
 		var doc = this;
 
 		// Check if the key is already set
-		if (doc[options.key]) {
+		if (!doc.isNew) {
 			return next();
 		}
 


### PR DESCRIPTION
Undefined ID doesn't mean that the doc is new, which can also mean the path is not selected.Using "isNew" can eliminate this ambiguity.
