### PR TITLE
Access the correct value

### DIFF
--- a/lib/shortid.js
+++ b/lib/shortid.js
@@ -102,7 +102,7 @@ exports.plugin = function(schema, options) {
 				}, function (err, res) {
 
 					if (!err) {
-						doc[options.key] = serializer(res.counter - 1, doc);
+						doc[options.key] = serializer(res.value.counter - 1, doc);
 					}
 					next(err);
 				});


### PR DESCRIPTION
The response of `findAndModify` looks like the following since v2.2 of mongo (see [docs](https://docs.mongodb.com/v2.2/reference/command/findAndModify/))

```
{
   lastErrorObject: {
                        updatedExisting: <boolean>,
                        upserted: <boolean>,
                        n: <num>,
                        connectionId: <num>,
                        err: <string>,
                        ok: <num>
   }
   value: <document>,
   ok: <num>
}
```

Thus, the counter is accessible as `res.value.counter`.
